### PR TITLE
Allow prediction on input sentences

### DIFF
--- a/src/extractive.py
+++ b/src/extractive.py
@@ -2,6 +2,7 @@ import os
 import sys
 import glob
 import logging
+import types
 from typing import List, Union
 import numpy as np
 from functools import partial
@@ -13,7 +14,6 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from spacy.lang.en import English
-from spacy.tokens import doc as spacy_doc
 from pooling import Pooling
 from data import SentencesProcessor, FSIterableDataset, pad_batch_collate
 from classifier import (
@@ -956,11 +956,11 @@ class ExtractiveSummarizer(pl.LightningModule):
             self.log(name, value, prog_bar=False)
 
     def predict_sentences(
-        self, input_sentences: Union[List[str], spacy_doc.Doc], raw_scores=False, num_summary_sentences=3, tokenized=False
+        self, input_sentences: Union[List[str], types.GeneratorType], raw_scores=False, num_summary_sentences=3, tokenized=False
     ):
         # Create source text.
         # Don't add periods when joining because that creates a space before the period.
-        if tokenized or type(input_sentences) is spacy_doc.Doc:
+        if tokenized:
             src_txt = [
                 " ".join([token.text for token in sentence if str(token) != "."]) + "."
                 for sentence in input_sentences

--- a/src/extractive.py
+++ b/src/extractive.py
@@ -13,7 +13,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from spacy.lang.en import English
-from spacy.tokens import doc
+from spacy.tokens import doc as spacy_doc
 from pooling import Pooling
 from data import SentencesProcessor, FSIterableDataset, pad_batch_collate
 from classifier import (
@@ -956,11 +956,11 @@ class ExtractiveSummarizer(pl.LightningModule):
             self.log(name, value, prog_bar=False)
 
     def predict_sentences(
-        self, input_sentences: Union[List[str], doc.Doc], raw_scores=False, num_summary_sentences=3, tokenized=False
+        self, input_sentences: Union[List[str], spacy_doc.Doc], raw_scores=False, num_summary_sentences=3, tokenized=False
     ):
         # Create source text.
         # Don't add periods when joining because that creates a space before the period.
-        if tokenized or type(input_sentences) is doc.Doc:
+        if tokenized or type(input_sentences) is spacy_doc.Doc:
             src_txt = [
                 " ".join([token.text for token in sentence if str(token) != "."]) + "."
                 for sentence in input_sentences
@@ -969,7 +969,7 @@ class ExtractiveSummarizer(pl.LightningModule):
             nlp = English()
             sentencizer = nlp.create_pipe("sentencizer")
             nlp.add_pipe(sentencizer)
-            
+
             src_txt = [
                 " ".join([token.text for token in nlp(sentence) if str(token) != "."]) + "."
                 for sentence in input_sentences

--- a/src/extractive.py
+++ b/src/extractive.py
@@ -2,6 +2,7 @@ import os
 import sys
 import glob
 import logging
+from typing import List
 import numpy as np
 from functools import partial
 from collections import OrderedDict
@@ -1035,8 +1036,8 @@ class ExtractiveSummarizer(pl.LightningModule):
         nlp.add_pipe(sentencizer)
         doc = nlp(input_text)
 
-        return predict_sentences(
-            input_sentences=list(doc.sents),
+        return self.predict_sentences(
+            input_sentences=[sent.text for sent in doc.sents],
             raw_scores=raw_scores,
             num_summary_sentences=num_summary_sentences,
         )

--- a/src/extractive.py
+++ b/src/extractive.py
@@ -958,6 +958,24 @@ class ExtractiveSummarizer(pl.LightningModule):
     def predict_sentences(
         self, input_sentences: Union[List[str], types.GeneratorType], raw_scores=False, num_summary_sentences=3, tokenized=False
     ):
+        """Summarizes ``input_sentences`` using the model.
+
+        Args:
+            input_sentences (list or generator): The sentences to be summarized.
+            raw_scores (bool, optional): Return a list containing each sentence
+                and its corespoding score instead of the summary. Defaults to False.
+            num_summary_sentences (int, optional): The number of sentences in the
+                output summary. This value specifies the number of top sentences to
+                select as the summary. Defaults to 3.
+            tokenized (bool, optional): If the input sentences are already tokenized
+                using spacy. If true, ``input_sentences`` should be a list of lists
+                where the outer list contains sentences and the inner lists contain
+                tokens. Defaults to False.
+
+        Returns:
+            str: The summary text. If ``raw_scores`` is set then returns a list
+            of input sentences and their corespoding scores.
+        """
         # Create source text.
         # Don't add periods when joining because that creates a space before the period.
         if tokenized:
@@ -1027,18 +1045,18 @@ class ExtractiveSummarizer(pl.LightningModule):
         return " ".join(selected_sents).strip()
 
     def predict(self, input_text: str, raw_scores=False, num_summary_sentences=3):
-        """Summaries ``input_text`` using the model.
+        """Summarizes ``input_text`` using the model.
 
         Args:
             input_text (str): The text to be summarized.
-            raw_scores (bool, optional): Return a dictionary containing each sentence
+            raw_scores (bool, optional): Return a list containing each sentence
                 and its corespoding score instead of the summary. Defaults to False.
             num_summary_sentences (int, optional): The number of sentences in the
                 output summary. This value specifies the number of top sentences to
                 select as the summary. Defaults to 3.
 
         Returns:
-            str: The summary text. If ``raw_scores`` is set then returns a dictionary
+            str: The summary text. If ``raw_scores`` is set then returns a list
             of input sentences and their corespoding scores.
         """
         nlp = English()

--- a/src/extractive.py
+++ b/src/extractive.py
@@ -961,7 +961,10 @@ class ExtractiveSummarizer(pl.LightningModule):
         """Summarizes ``input_sentences`` using the model.
 
         Args:
-            input_sentences (list or generator): The sentences to be summarized.
+            input_sentences (list or generator): The sentences to be summarized as a
+                list or a generator of spacy Spans (``spacy.tokens.span.Span``), which
+                can be obtained by running ``nlp("input document").sents`` where
+                ``nlp`` is a spacy model with a sentencizer.
             raw_scores (bool, optional): Return a list containing each sentence
                 and its corespoding score instead of the summary. Defaults to False.
             num_summary_sentences (int, optional): The number of sentences in the


### PR DESCRIPTION
Changes:
- Separate `predict_sentences` from `predict` which works on input text. 
- Return `list` when raw_scores=True instead of `dict`. This is because we might have the same text such as "Thank you."  appear in multiple places in the text. However, their score might be different since they are at different positions/context. Using a `dict` overwrites the previous position's score.

