### PR TITLE
Fix segment ids and sentence lengths

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -544,6 +544,8 @@ class SentencesProcessor:
                         sent_rep_ids[i] - sent_rep_ids[i - 1]
                         for i in range(1, len(sent_rep_ids))
                     ]
+                    # add sentence length for the last sentence
+                    sent_lengths.append(len(sent_rep_ids) - sent_rep_ids[-1])
 
         # Attention
         # The mask has 1 for real tokens and 0 for padding tokens. Only real

--- a/src/data.py
+++ b/src/data.py
@@ -511,17 +511,17 @@ class SentencesProcessor:
             current_segment_flag = True
             segment_ids = []
             for token in input_ids:
+                segment_ids += [0 if current_segment_flag else 1]
                 if token == segment_token_id:
                     current_segment_flag = not current_segment_flag
-                segment_ids += [0 if current_segment_flag else 1]
 
         if create_segment_ids == "sequential":
             current_segment = 0
             segment_ids = []
             for token in input_ids:
+                segment_ids += [current_segment]
                 if token == segment_token_id:
                     current_segment += 1
-                segment_ids += [current_segment]
 
         # Sentence Representation Token IDs and Sentence Lengths
         sent_rep_ids = None


### PR DESCRIPTION
- By default, since we use `segment_token_id` to be SEP token, we need to toggle the `current_segment_flag` after appending it to the `segment_ids` list
- Sentence length for the last sentence was missing

Below example shows 2 sentences in `src`. However, `token_type_ids` / `segment_ids` indicate 3 sentences because of the toggle issue and `sent_lengths` indicate 1 sentence because it misses the last one.

Example output before PR:
```
In [7]: j[0]
Out[7]:
{'src': [['how',
   'do',
   'i',
   'do',
   'my',
   'chores',
   'my',
   'parents',
   'wants',
   'me',
   'to',
   'do',
   '.'],
  ['thank', 'you', 'so', 'much', '!']],
 'labels': [1, 0]}

In [8]: t[0]
Out[8]:
{'input_ids': [0,
  9178,
  109,
  939,
  109,
  127,
  21350,
  127,
  3254,
  1072,
  162,
  7,
  109,
  479,
  1437,
  2,
  1437,
  0,
  3392,
  47,
  98,
  203,
  27785,
  2],
 'token_type_ids': [0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  0,
  1,
  1,
  1,
  1,
  1,
  1,
  1,
  1,
  0],
 'labels': [1, 0],
 'sent_rep_token_ids': [0, 17],
 'sent_lengths': [17]}
```

The changes in this PR would match the segment_id alignment from the BertSum paper:
![Screen Shot 2020-10-28 at 5 16 54 PM](https://user-images.githubusercontent.com/7154255/97497796-6dc30c80-1941-11eb-841c-d80045ca484c.png)
