### PR TITLE
Add support for different AMP backends

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -248,7 +248,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--amp_backend",
         type=str,
-        default="apex",
+        default="native",
         choices=["native", "apex"],
         help="PyTorch Lightning amp_backend ('native' or 'apex')",
     )

--- a/src/main.py
+++ b/src/main.py
@@ -241,9 +241,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--amp_level",
         type=str,
-        default="O1",
+        default=None,
         help="The optimization level to use (O1, O2, etc…) for 16-bit GPU precision (using "
         + "NVIDIA apex under the hood).",
+    )
+    parser.add_argument(
+        "--amp_backend",
+        type=str,
+        default="apex",
+        choices=["native", "apex"],
+        help="PyTorch Lightning amp_backend ('native' or 'apex')",
     )
     parser.add_argument(
         "--precision",


### PR DESCRIPTION
When running TransformerSum with PyTorch 1.10.2, the training script fails with
``
pytorch_lightning.utilities.exceptions.MisconfigurationException: You have asked for `amp_level='O1'` but it's only supported with `amp_backend='apex'`. 
`` 

One of the GitHub issues has mentioned this problem, and the solution was to simply remove the argument. Instead, I think that a choice for the AMP backend should be added to the list of parameters of `main.py`.
In that case, the default value of `--amp_level` should be set to `None`, as PyTorch's native AMP backend does not support `--amp_level='O1'`.