### PR TITLE
Fix a missing parameter error in PyTorch Lightning

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -92,16 +92,17 @@ def main(args):
         try:
             args.checkpoint_callback = ModelCheckpoint(
                 save_top_k=-1,
-                period=1,
+                every_n_epochs=1,
                 verbose=True,
             )
         except TypeError:
             logger.warning(
-                "'period' parameter of ModelCheckpoint has been renamed to 'every_n_epochs'."
+                "'every_n_epochs' parameter of ModelCheckpoint is not found. "
+                + "Defaulting to its old name, 'period'."
             )
             args.checkpoint_callback = ModelCheckpoint(
                 save_top_k=-1,
-                every_n_epochs=1,
+                period=1,
                 verbose=True,
             )
 

--- a/src/main.py
+++ b/src/main.py
@@ -89,11 +89,22 @@ def main(args):
         args.logger = wandb_logger
 
     if args.use_custom_checkpoint_callback:
-        args.checkpoint_callback = ModelCheckpoint(
-            save_top_k=-1,
-            period=1,
-            verbose=True,
-        )
+        try:
+            args.checkpoint_callback = ModelCheckpoint(
+                save_top_k=-1,
+                period=1,
+                verbose=True,
+            )
+        except TypeError:
+            logger.warning(
+                "'period' parameter of ModelCheckpoint has been renamed to 'every_n_epochs'."
+            )
+            args.checkpoint_callback = ModelCheckpoint(
+                save_top_k=-1,
+                every_n_epochs=1,
+                verbose=True,
+            )
+
     if args.custom_checkpoint_every_n:
         custom_checkpoint_callback = StepCheckpointCallback(
             step_interval=args.custom_checkpoint_every_n,


### PR DESCRIPTION
One of the updates of PyTorch Lightning has renamed the `period` parameter of `ModelCheckpoint`'s constructor to `every_n_epochs`. For example, for 1.5.9, running the reproducing commands for the experiments yields a `TypeError` because of this change.

This pull requests adds a try-except case to check, which of the two names is accepted by the user's version of PyTorch Lightning.