### PR TITLE
Bug fixed when tokenizer has missing 'pad_token'

### DIFF
--- a/src/abstractive.py
+++ b/src/abstractive.py
@@ -142,6 +142,7 @@ class AbstractiveSummarizer(pl.LightningModule):
             self.target_eoseq_token = self.tokenizer.pad_token
         else:
             self.target_eoseq_token = "[unused1]"
+            self.tokenizer.pad_token = "[unused2]"
             do_seq_special_add = True
 
         # Convert `target_boseq_token` and `target_eoseq_token` to IDs


### PR DESCRIPTION
When `self.tokenizer.pad_token is None`, `self.tokenizer.pad_token_id` will also be None (to ensure, one can check on `AutoTokenizer.from_pretrained('sberbank-ai/rugpt3small_based_on_gpt2')`). Consequently, this will lead to errors (e.g. in lines 171, 175 in `abstractive.py`) when using `self.tokenizer.pad_token_id`. 

Added a small fix that will add `pad_token` to the tokenizer (`tokenizer.pad_token_id` and `tokenizer.special_tokens_map` update automatically).