### PR TITLE
Updated to fix E966 in spacy

### DIFF
--- a/src/extractive.py
+++ b/src/extractive.py
@@ -1098,7 +1098,14 @@ class ExtractiveSummarizer(pl.LightningModule):
         else:
             nlp = English()
             sentencizer = nlp.create_pipe("sentencizer")
-            nlp.add_pipe(sentencizer)
+            try:
+                nlp.add_pipe(sentencizer)
+            except ValueError as e:
+                if e.args[0].startswith("[E966]"):
+                    nlp.add_pipe("sentencizer")
+                else:
+                    raise e
+
 
             src_txt = [
                 " ".join([token.text for token in nlp(sentence) if str(token) != "."])


### PR DESCRIPTION
When I tried executing a part in `extractive`, I get the following error

```
ValueError: [E966] `nlp.add_pipe` now takes the string name of the registered component factory, not a callable component. Expected string, but got <spacy.pipeline.sentencizer.Sentencizer object at 0x7f9fde2b6080> (name: 'None').                                                                                               
- If you created your component with `nlp.create_pipe('name')`: remove nlp.create_pipe and call `nlp.add_pipe('name')` instead.
                                                                                                                 
- If you passed in a component like `TextCategorizer()`: call `nlp.add_pipe` with the string name instead, e.g. `nlp.add_pipe('textcat')`.                                                                                                                                        
                                                                             
- If you're using a custom component: Add the decorator `@Language.component` (for function components) or `@Language.factory` (for class
 components / factories) to your custom component and assign it a name, e.g. `@Language.component('your_name')`. You can then run `nlp.ad
d_pipe('your_name')` to add it to the pipeline.                     
```

which can be resolved by this PR.

Essentially, the name needs to be passed into `nlp.add_pipe`, instead of the Sentencizer